### PR TITLE
Compatibility with GHC 9.8

### DIFF
--- a/text-replace/text-replace.cabal
+++ b/text-replace/text-replace.cabal
@@ -32,7 +32,7 @@ common base
     default-language: Haskell2010
     ghc-options: -Wall
     build-depends:
-        base ^>= 4.14 || ^>= 4.15 || ^>= 4.16 || ^>= 4.17
+        base >= 4.14 && < 4.20
       , text ^>= 1.2.4 || ^>= 2.0
 
 library

--- a/text-replace/text-replace.cabal
+++ b/text-replace/text-replace.cabal
@@ -47,7 +47,7 @@ executable text-replace
     hs-source-dirs: app
     main-is: text-replace.hs
     build-depends:
-        optparse-applicative ^>= 0.16.1 || ^>= 0.17
+        optparse-applicative >= 0.16.1 && < 0.19
       , parsec ^>= 3.1.14
       , text-replace
 


### PR DESCRIPTION
This package is preventing [Granule](https://github.com/granule-project/granule) from compiling on newer GHC versions.